### PR TITLE
Add support for Hidden NTFS partition

### DIFF
--- a/source/mbr.h
+++ b/source/mbr.h
@@ -8,6 +8,7 @@
 #define MBR_PARTITION_TYPE_SLCCMPT 0x0D
 #define MBR_PARTITION_TYPE_MLC 0x83 // Linux ext
 #define NTFS 0x07 
+#define NTFS_HIDDEN 0x27
 #define MBR_PARTITION_TYPE_MLC_NOSCFM NTFS
 
 typedef struct {

--- a/source/sal_mbr.c
+++ b/source/sal_mbr.c
@@ -20,7 +20,8 @@ static partition_entry* find_usb_partition(mbr_sector* mbr){
     u32 selected_start = 0;
     for (size_t i = 1; i < MBR_MAX_PARTITIONS; i++){
         u32 istart = LD_DWORD(mbr->partition[i].lba_start);
-        if(mbr->partition[i].type == NTFS && (selected_start < istart)){
+        u8 ptype = mbr->partition[i].type;
+        if((ptype == NTFS || ptype == NTFS_HIDDEN) && (selected_start < istart)){
             selected = mbr->partition+i;
             selected_start = istart;
         }


### PR DESCRIPTION
Very simple change to add support for partitions marked as 0x27 (Hidden NTFS).
By using this partition type we can avoid the annoying Windows popup asking to format the partition every time you plug the SD card to a PC.

I haven't really tested this as I don't know how to compile but it should work just fine as it's a very simple change.